### PR TITLE
Actuatorの導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,9 @@ graph TD;
   - `V{バージョン番号}__{説明}.sql`
 - flywayは実行済みのsqlファイルは変更しても動きません。新しいsqlファイルを作成する必要があります。
 - `./gradlew flywayClean`というコマンドでDB内の全てのテーブルとデータが削除されます。これにより、実行済みのsqlファイルも未実行ファイルという扱いに戻ります。
+
+## エンドポイント
+
+### Swagger UI
+
+- [Swagger UI](http://localhost:9090/manage/actuator/swagger-ui/index.html)

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 	implementation 'org.flywaydb:flyway-core:11.3.4'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'org.postgresql:postgresql'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql:11.3.4'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/kotlin/jp/mentor/app/config/CorsConfig.kt
+++ b/src/main/kotlin/jp/mentor/app/config/CorsConfig.kt
@@ -1,0 +1,20 @@
+package jp.mentor.app.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * corsの設定.
+ */
+@Configuration
+class CorsConfig: WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        // swaggerがアクセスするURLとAPIを許可
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:9090")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+    }
+}

--- a/src/main/kotlin/jp/mentor/app/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/jp/mentor/app/config/SwaggerConfiguration.kt
@@ -1,0 +1,29 @@
+package jp.mentor.app.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * swaggerの設定.
+ */
+@Configuration
+class SwaggerConfiguration {
+    @Bean
+    fun openApi(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("riddle API")
+                    .description("謎解きアプリに備わっているAPIを提供します")
+                    .version("1.0.0")
+                    .license(
+                        License()
+                            .name("Apache 2.0")
+                            .url("https://www.apache.org/licenses/LICENSE-2.0")
+                    )
+            )
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,4 @@
+# springの基本設定
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5433/app
@@ -14,6 +15,33 @@ spring:
     location: classpath:db/migration
     default-schema: app
     schemas: app
+
+# swaggerの設定
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+
+# actuatorの設定
+management:
+  server:
+    port: 9090
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: "always"
+    shutdown:
+      enabled: false
+  health:
+    livenessState:
+      enabled: true
+    readinessState:
+      enabled: true
+    db:
+      enabled: true
+    diskspace:
+      enabled: true
+    ping:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,6 @@ management:
     web:
       exposure:
         include: "*"
-  endpoint:
     health:
       show-details: "always"
     shutdown:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,13 +18,17 @@ spring:
 
 # swaggerの設定
 springdoc:
+  api-docs:
+    path: /api-docs
   swagger-ui:
-    path: /swagger-ui.html
+    path: /swagger-ui
+  use-management-port: true
 
 # actuatorの設定
 management:
   server:
     port: 9090
+    base-path: /manage
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## 概要
- springアプリケーションにActuatorを導入
- swagger UIをActuatorから参照できるように変更
  - 参照のために設定ファイル作成
- READMEにswggar UIの導線追加

## issue
- #26 

## 追加/変更内容
- [x] `build.gradle`にactuatorの追加(gradleタスクの更新必須)
- [x] `application.yml`のactuator設定追加
- [x] actuator用の設定ファイル作成
- [x] READMEにswagger UIのリンク追加

## 確認事項
- [x] swagger UIにアクセスできるか
- [x] swagger UIのサンプルのエンドポイントが機能するか