### PR TITLE
archunit用のタスク作成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ allOpen {
 }
 
 tasks.named('test') {
+	exclude("**/archunit/ArchUnitTest.class")
 	useJUnitPlatform()
 }
 
@@ -71,4 +72,11 @@ flyway {
 	password = 'postgres'
 	schemas = ['public']
 	cleanDisabled = false
+}
+
+tasks.register("archunitTest", Test) {
+	// ArchUnit のテストクラスだけを対象にする
+	include("**/archunit/ArchUnitTest.class")
+
+	useJUnitPlatform()
 }

--- a/src/test/kotlin/jp/mentor/app/archunit/ArchUnitTest.kt
+++ b/src/test/kotlin/jp/mentor/app/archunit/ArchUnitTest.kt
@@ -1,4 +1,4 @@
-package jp.mentor.app
+package jp.mentor.app.archunit
 
 import com.tngtech.archunit.core.domain.JavaClasses
 import com.tngtech.archunit.core.importer.ImportOption


### PR DESCRIPTION
## 概要
- gradleのテストタスクにおいて、UTなどのテストとarchUnitテストを分離

## issue
- #28 

## 追加/変更内容
- [x] 既存のarchUnitTestファイルを別ディレクトリに移動
- [x] `./gradlew test`からarchUnitのみ分離し、archUnitのみのgradleタスク作成

## 確認事項
- [ ] `./gradlew test`でarchUnitのみが動作しない
- [ ] `./gradlew archunitTest`でarchUnitのみが動作する